### PR TITLE
Add RSS feed link to head

### DIFF
--- a/src/core.clj
+++ b/src/core.clj
@@ -117,6 +117,11 @@ style-src       'self' 'unsafe-inline'
    ;; icons
    [:link {:rel  "shortcut icon"
            :href (str site-url "assets/favicon.png")}]
+   ;; rss
+   [:link {:rel "alternate"
+           :type "application/rss+xml"
+           :title "Blog Posts"
+           :href site-rss}]
    ;; javascript
    [:script {:defer true
              :src   (str site-url "toggle.js")}]


### PR DESCRIPTION
This PR adds a missing link tag to your head element that allows feed readers to automatically identify the RSS feed address.